### PR TITLE
Allow args with events

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -74,9 +74,9 @@ RegisterNUICallback('click', function(data, cb)
     end
 
     if data.event then
-        TriggerEvent(data.event)
+        local args = data.args or {} 
+        TriggerEvent(data.event, args)
     end
-end)
 
 exports('OpenDialog', OpenDialog)
 exports('SetDialog', SetDialog)


### PR DESCRIPTION
Allows for the use of args in the data section.

Example usage in config:
```
{
   text = 'Give me the medium route.',
   event = 'Renewed-Garbage:client:clientChecks',
   args = {
      size = 'medium',
   },
   close = true,
}
```
